### PR TITLE
Simple script to kexec rather than reboot - borrows code already in A…

### DIFF
--- a/scripts/setup_kexec.py
+++ b/scripts/setup_kexec.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python
+
+import pyanaconda.iutil
+
+def _getSysroot():
+	return "/"
+
+pyanaconda.iutil.getSysroot=_getSysroot
+
+from pyanaconda.kexec import setup_kexec
+
+setup_kexec()


### PR DESCRIPTION
…naconda

Pavel, we can discuss how best to incorporate this into the build, but I wanted to capture a copy here.

This requires "anaconda-core" in the image.  It populates the kernel, initrd and command line as GRUB would otherwise execute them, using the "grubby" tool.

Once this script is run "systemctl kexec" will do a graceful system shutdown followed by a kexec instead of a reset/reboot.

On our test hardware this takes less than a minute to complete.